### PR TITLE
Add MQTT discovery support for homeassistant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 android {
@@ -72,6 +73,7 @@ dependencies {
     implementation("com.google.dagger:dagger:$daggerVersion")
     ksp("com.google.dagger:dagger-compiler:$daggerVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("io.github.davidepianca98:kmqtt-common-jvm:$kmqttVersion")
     implementation("io.github.davidepianca98:kmqtt-client-jvm:$kmqttVersion")
 }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -111,9 +111,8 @@ class MainWorker @Inject constructor(
             name = "MediaSession2MQTT",
             manufacturer = Build.MANUFACTURER,
             model = Build.MODEL,
-            identifiers = listOf(deviceId.toString())
+            identifiers = listOf("MediaSession2MQTT_$deviceId")
         )
-
 
         val sensors = listOf(
             "Application ID" to APPLICATION_ID_SUB_TOPIC,

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -107,7 +107,6 @@ class MainWorker @Inject constructor(
             val device: DeviceInfo
         )
 
-
         val deviceInfo = DeviceInfo(
             name = "MediaSession2MQTT",
             manufacturer = Build.MANUFACTURER,
@@ -117,14 +116,14 @@ class MainWorker @Inject constructor(
 
 
         val sensors = listOf(
-            Pair("Application ID", "$APPLICATION_ID_SUB_TOPIC"),
-            Pair("Playback state", "$PLAYBACK_STATE_SUB_TOPIC"),
-            Pair("Media title", "$MEDIA_TITLE_SUB_TOPIC"),
+            "Application ID" to APPLICATION_ID_SUB_TOPIC,
+            "Playback state" to PLAYBACK_STATE_SUB_TOPIC,
+            "Media title" to MEDIA_TITLE_SUB_TOPIC,
         )
 
         sensors.forEach { (name, topic) ->
             val serializedName = name.lowercase().replace(' ', '_')
-            val uniqueId = "mediaSession_${serializedName}"
+            val uniqueId = "mediaSession_${deviceId}_${serializedName}"
 
             val sensor = Sensor(
                 name = name,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22" apply false
 }


### PR DESCRIPTION
Hi and thanks for creating this project! I (once again) got frustrated with the android integration, and started to look (once again) if I could try to turn my previous experiments on java-written "mediasessionbridge" into something usable in production. While trying to find some code examples on github, I stumbled upon your project and was really happy to find an existing project that advertises to do *exactly* what I wanted :-)

To make onboarding smoother, this PR adds a proof-of-concept support for [MQTT discovery used by Homeassistant](https://www.home-assistant.io/integrations/mqtt/#discovery-options) to automatically create devices and entities.

![image](https://github.com/cbeyls/MediaSession2MQTT/assets/3705853/2f376272-a45e-424c-9fa0-8bd742f42227)

As this is my first time writing anything in Kotlin, any feedback is very welcome! Btw, you may want to advertise this also on the homeassistant's community forums, I'm sure there are many who'd like to use this. Even more so, if it'd be directly available from the appstores.