### PR TITLE
Rebind notification listener after device reboot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".MainApplication"
@@ -29,6 +30,14 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".service.BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/service/BootReceiver.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/service/BootReceiver.kt
@@ -1,0 +1,52 @@
+package be.digitalia.mediasession2mqtt.service
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.service.notification.NotificationListenerService
+
+/**
+ * Works around a well-known Android bug where the [NotificationListenerService] is not
+ * automatically re-bound after a device reboot. When this happens the app silently stops
+ * receiving media session updates until the notification access permission is manually
+ * toggled off and on again (a frequent problem on Android TV).
+ *
+ * On boot we force the system to rebind the listener:
+ *  1. Disabling then re-enabling the service component. This is the programmatic equivalent
+ *     of the manual permission toggle and reliably triggers a rebind, including on the
+ *     devices where the official API alone is not enough. It does not affect the granted
+ *     notification-access permission (that grant is stored separately, by component name).
+ *  2. [NotificationListenerService.requestRebind] — the official API (API 24+) as a final nudge.
+ */
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        val component = ComponentName(context, MediaSessionListenerService::class.java)
+
+        // (1) Forceful rebind: toggle the component off and back on.
+        runCatching {
+            val pm = context.packageManager
+            pm.setComponentEnabledSetting(
+                component,
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP
+            )
+            pm.setComponentEnabledSetting(
+                component,
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP
+            )
+        }
+
+        // (2) Ask the system to rebind the listener (available since API 24).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            runCatching {
+                NotificationListenerService.requestRebind(component)
+            }
+        }
+    }
+}


### PR DESCRIPTION
On many devices — notably Android TV — the system fails to re-bind the `NotificationListenerService` after a reboot. When this happens the app silently stops publishing media session state to MQTT until the user manually toggles the notification access permission off and on again.

This PR adds a `BOOT_COMPLETED` broadcast receiver that forces the system to rebind the listener on boot:

1. Toggling the service component off and back on (the programmatic equivalent of the manual permission toggle), which reliably triggers a rebind — including on devices where the official API alone isn't enough.
2. Calling `NotificationListenerService.requestRebind()` (API 24+) as a final nudge.

The notification-access grant is stored separately (by component name) and is not affected by the component toggle. Failures are caught defensively so the receiver never crashes on boot.

Tested on a **Philips Android TV (Android 12)**: after a reboot the listener reconnects automatically and playback state keeps publishing without any manual intervention.

**Reference:** https://stackoverflow.com/a/64576489

Fixes #7 · May also address #12
