### PR TITLE
fix: auto rebind service on device startup and add watchdog to auto-rebind the service after 2 seconds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".MainApplication"
@@ -29,6 +30,14 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name=".service.BootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainApplication.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainApplication.kt
@@ -16,6 +16,6 @@ class MainApplication : Application(), ApplicationComponentProvider {
     override fun onCreate() {
         super.onCreate()
 
-        applicationComponent.mainWorker.start()
+        applicationComponent.mainWorker.start(this)
     }
 }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -1,5 +1,6 @@
 package be.digitalia.mediasession2mqtt
 
+import android.content.Context
 import be.digitalia.mediasession2mqtt.flow.collectWithPrevious
 import be.digitalia.mediasession2mqtt.homeassistant.Sensor
 import be.digitalia.mediasession2mqtt.homeassistant.createSensorDiscoveryConfiguration
@@ -14,24 +15,26 @@ import be.digitalia.mediasession2mqtt.mqttmediaplayer.MQTTPlaybackState
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMQTTPlaybackStateOrNull
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaDurationInMillis
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaTitle
+import be.digitalia.mediasession2mqtt.service.MediaSessionListenerService
 import be.digitalia.mediasession2mqtt.settings.SettingsProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class MainWorker @Inject constructor(
-    currentMediaControllerDetector: CurrentMediaControllerDetector,
+    private val currentMediaControllerDetector: CurrentMediaControllerDetector,
     private val settingsProvider: SettingsProvider,
     private val mqttClientFactory: MQTTPublishClient.Factory
 ) {
@@ -47,9 +50,7 @@ class MainWorker @Inject constructor(
         currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
             when (mediaController) {
                 null -> flowOf(MQTTPlaybackState.Idle)
-                else -> mediaController.playbackStateFlow
-                    .map { it.toMQTTPlaybackStateOrNull() }
-                    .filterNotNull()
+                else -> mediaController.playbackStateFlow.mapNotNull { it.toMQTTPlaybackStateOrNull() }
             }
         }
 
@@ -175,13 +176,24 @@ class MainWorker @Inject constructor(
         }
     }
 
-    fun start() {
+    fun start(context: Context) {
         coroutineScope.launch {
             monitorSettings()
+        }
+        // Watchdog to attempt rebinding MediaSessionListenerService when disconnected
+        coroutineScope.launch {
+            currentMediaControllerDetector.isListening.collectLatest { isListening ->
+                if (!isListening) {
+                    delay(AUTO_REBIND_SERVICE_DELAY_MILLIS)
+                    MediaSessionListenerService.requestRebind(context)
+                }
+            }
         }
     }
 
     companion object {
+        private const val AUTO_REBIND_SERVICE_DELAY_MILLIS = 2000L
+
         private const val ROOT_TOPIC = "mediaSession"
         private const val APPLICATION_ID_SUB_TOPIC = "applicationId"
         private const val PLAYBACK_STATE_SUB_TOPIC = "playbackState"

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/service/BootReceiver.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/service/BootReceiver.kt
@@ -1,0 +1,16 @@
+package be.digitalia.mediasession2mqtt.service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Ensures MediaSessionListenerService is bound when the device boots.
+ */
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            MediaSessionListenerService.requestRebind(context)
+        }
+    }
+}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/service/MediaSessionListenerService.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/service/MediaSessionListenerService.kt
@@ -1,6 +1,8 @@
 package be.digitalia.mediasession2mqtt.service
 
 import android.content.ComponentName
+import android.content.Context
+import android.os.Build
 import android.service.notification.NotificationListenerService
 import be.digitalia.mediasession2mqtt.inject.applicationComponent
 import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
@@ -26,9 +28,14 @@ class MediaSessionListenerService : NotificationListenerService() {
         super.onListenerDisconnected()
     }
 
-    override fun onDestroy() {
-        // In case the service is destroyed prematurely
-        currentMediaControllerDetector.stopListening()
-        super.onDestroy()
+    companion object {
+        fun requestRebind(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                try {
+                    requestRebind(ComponentName(context, MediaSessionListenerService::class.java))
+                } catch (_: Exception) {
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Attempts to fix #7 and #12.

If that fix is not enough, we can attempt to disable and re-enable the service component as well on device startup.