### PR TITLE
feat: publish media artwork over MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This app provides an integration for Home Assistant since version 1.1.0. Check t
 
 This application is designed to only push state messages and not listen to MQTT commands. The MQTT connection is kept open as long as possible and no keepalive packets are sent. If the connection gets interrupted for any reason, it will be automatically re-established lazily when the next MQTT message needs to be published.
 
-The application publishes the following 3 topics to the MQTT broker (replace `{deviceId}` with your actual device id which is `1` by default):
+The application publishes the following topics to the MQTT broker (replace `{deviceId}` with your actual device id which is `1` by default):
 
 ### mediaSession/{deviceId}/playbackState
 The current playback state of the player connected to the current MediaSession, if any. Can be one of the following values: `idle`, `playing`, `paused`.
@@ -154,6 +154,12 @@ Note that many applications don't report any title, for example: Netflix, Disney
 ### mediaSession/{deviceId}/mediaDuration
 
 The duration of the currently playing or paused media in milliseconds, or an empty String (`""`) if no media is currently playing or paused or the duration is unavailable.
+
+### mediaSession/{deviceId}/mediaArtwork
+
+The artwork of the currently playing media as raw JPEG bytes. The payload is retained and is suitable for Home Assistant's MQTT `image` integration. When Home Assistant integration is enabled, a `Media Artwork` image entity is created automatically through MQTT discovery.
+
+The app first uses artwork supplied directly by the active Android MediaSession. If an application only exposes an HTTP(S) artwork URI, it downloads and normalizes that image to JPEG before publishing it.
 
 ## A note about the Netflix app
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ The duration of the currently playing or paused media in milliseconds, or an emp
 
 ### mediaSession/{deviceId}/mediaArtwork
 
-The artwork of the currently playing media as raw JPEG bytes. The payload is retained and is suitable for Home Assistant's MQTT `image` integration. When Home Assistant integration is enabled, a `Media Artwork` image entity is created automatically through MQTT discovery.
+The artwork of the currently playing media as raw PNG bytes. The payload is retained and is suitable for Home Assistant's MQTT `image` integration. When Home Assistant integration is enabled, a `Media Artwork` image entity is created automatically through MQTT discovery.
 
-The app first uses artwork supplied directly by the active Android MediaSession. If an application only exposes an HTTP(S) artwork URI, it downloads and normalizes that image to JPEG before publishing it.
+The app first uses artwork supplied directly by the active Android MediaSession. If an application only exposes an HTTP(S) artwork URI, it downloads and encodes that image as PNG at its original dimensions before publishing it.
 
 ## A note about the Netflix app
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -11,12 +11,11 @@ import be.digitalia.mediasession2mqtt.mediasession.playbackStateFlow
 import be.digitalia.mediasession2mqtt.mqtt.MQTTPublishClient
 import be.digitalia.mediasession2mqtt.mqtt.MQTTQoSLevel
 import be.digitalia.mediasession2mqtt.mqtt.tryConnectAndPublish
+import be.digitalia.mediasession2mqtt.mqttmediaplayer.ArtworkRepository
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.MQTTMediaMetadata
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.MQTTPlaybackState
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.getPlayingPositionDrift
-import be.digitalia.mediasession2mqtt.mqttmediaplayer.resolveArtworkJpeg
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMQTTPlaybackStateOrNull
-import be.digitalia.mediasession2mqtt.mqttmediaplayer.toArtworkCacheKey
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaDurationInMillis
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaTitle
 import be.digitalia.mediasession2mqtt.service.MediaSessionListenerService
@@ -33,12 +32,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -48,7 +46,8 @@ class MainWorker(
     private val context: Context,
     private val currentMediaControllerDetector: CurrentMediaControllerDetector,
     private val settingsProvider: SettingsProvider,
-    private val mqttClientFactory: MQTTPublishClient.Factory
+    private val mqttClientFactory: MQTTPublishClient.Factory,
+    private val artworkRepository: ArtworkRepository
 ) {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -84,26 +83,6 @@ class MainWorker(
                             title = it.toMediaTitle(),
                             durationInMillis = it.toMediaDurationInMillis()
                         )
-                    }
-            }
-        }.buffer(Channel.RENDEZVOUS)
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private val mediaArtworkFlow: Flow<ByteArray> =
-        currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
-            when (mediaController) {
-                null -> flowOf(ByteArray(0))
-                else -> mediaController.metadataFlow
-                    .map { metadata ->
-                        Triple(
-                            mediaController.packageName,
-                            metadata.toArtworkCacheKey(mediaController.packageName),
-                            metadata
-                        )
-                    }
-                    .distinctUntilChangedBy { (_, cacheKey, _) -> cacheKey }
-                    .mapLatest { (_, _, metadata) ->
-                        resolveArtworkJpeg(metadata)
                     }
             }
         }.buffer(Channel.RENDEZVOUS)
@@ -233,15 +212,12 @@ class MainWorker(
         qosLevel: MQTTQoSLevel,
         deviceId: Int
     ) {
-        mediaArtworkFlow.fold(null as ByteArray?) { previousArtwork, artwork ->
-            if (previousArtwork == null || !previousArtwork.contentEquals(artwork)) {
-                client.tryConnectAndPublish(
-                    qosLevel,
-                    "$ROOT_TOPIC/$deviceId/$MEDIA_ARTWORK_SUB_TOPIC",
-                    artwork
-                )
-            }
-            artwork
+        artworkRepository.artwork.filterNotNull().collect { artwork ->
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$MEDIA_ARTWORK_SUB_TOPIC",
+                artwork
+            )
         }
     }
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -3,6 +3,7 @@ package be.digitalia.mediasession2mqtt
 import android.content.Context
 import android.media.session.PlaybackState
 import be.digitalia.mediasession2mqtt.homeassistant.Sensor
+import be.digitalia.mediasession2mqtt.homeassistant.createImageDiscoveryConfiguration
 import be.digitalia.mediasession2mqtt.homeassistant.createSensorDiscoveryConfiguration
 import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
 import be.digitalia.mediasession2mqtt.mediasession.metadataFlow
@@ -13,7 +14,9 @@ import be.digitalia.mediasession2mqtt.mqtt.tryConnectAndPublish
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.MQTTMediaMetadata
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.MQTTPlaybackState
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.getPlayingPositionDrift
+import be.digitalia.mediasession2mqtt.mqttmediaplayer.resolveArtworkJpeg
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMQTTPlaybackStateOrNull
+import be.digitalia.mediasession2mqtt.mqttmediaplayer.toArtworkCacheKey
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaDurationInMillis
 import be.digitalia.mediasession2mqtt.mqttmediaplayer.toMediaTitle
 import be.digitalia.mediasession2mqtt.service.MediaSessionListenerService
@@ -30,10 +33,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -83,6 +88,26 @@ class MainWorker(
             }
         }.buffer(Channel.RENDEZVOUS)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val mediaArtworkFlow: Flow<ByteArray> =
+        currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
+            when (mediaController) {
+                null -> flowOf(ByteArray(0))
+                else -> mediaController.metadataFlow
+                    .map { metadata ->
+                        Triple(
+                            mediaController.packageName,
+                            metadata.toArtworkCacheKey(mediaController.packageName),
+                            metadata
+                        )
+                    }
+                    .distinctUntilChangedBy { (_, cacheKey, _) -> cacheKey }
+                    .mapLatest { (_, _, metadata) ->
+                        resolveArtworkJpeg(metadata)
+                    }
+            }
+        }.buffer(Channel.RENDEZVOUS)
+
     private suspend fun monitorSettings() {
         settingsProvider.connectionSettings.collectLatest { connectionSettings ->
             if (connectionSettings != null) {
@@ -94,6 +119,7 @@ class MainWorker(
                             launch { publishApplicationId(client, qosLevel, deviceId) }
                             launch { publishPlaybackState(client, qosLevel, deviceId) }
                             launch { publishMediaMetadata(client, qosLevel, deviceId) }
+                            launch { publishMediaArtwork(client, qosLevel, deviceId) }
                         }
                     }
                 } finally {
@@ -122,6 +148,16 @@ class MainWorker(
                         discoveryConfig
                     )
                 }
+
+                val artworkTopic = "$ROOT_TOPIC/$deviceId/$MEDIA_ARTWORK_SUB_TOPIC"
+                client.tryConnectAndPublish(
+                    qosLevel,
+                    "$HASS_ROOT_TOPIC/image/mediasession_${deviceId}_media_artwork/config",
+                    createImageDiscoveryConfiguration(
+                        deviceId = deviceId,
+                        imageTopic = artworkTopic
+                    )
+                )
             }
         }
     }
@@ -192,6 +228,23 @@ class MainWorker(
         }
     }
 
+    private suspend fun publishMediaArtwork(
+        client: MQTTPublishClient,
+        qosLevel: MQTTQoSLevel,
+        deviceId: Int
+    ) {
+        mediaArtworkFlow.fold(null as ByteArray?) { previousArtwork, artwork ->
+            if (previousArtwork == null || !previousArtwork.contentEquals(artwork)) {
+                client.tryConnectAndPublish(
+                    qosLevel,
+                    "$ROOT_TOPIC/$deviceId/$MEDIA_ARTWORK_SUB_TOPIC",
+                    artwork
+                )
+            }
+            artwork
+        }
+    }
+
     fun start() {
         coroutineScope.launch {
             monitorSettings()
@@ -217,6 +270,7 @@ class MainWorker(
         private const val PLAYBACK_POSITION_SUB_TOPIC = "playbackPosition"
         private const val MEDIA_TITLE_SUB_TOPIC = "mediaTitle"
         private const val MEDIA_DURATION_SUB_TOPIC = "mediaDuration"
+        private const val MEDIA_ARTWORK_SUB_TOPIC = "mediaArtwork"
 
         private const val HASS_ROOT_TOPIC = "homeassistant"
         private val HASS_SENSORS = listOf(

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/homeassistant/SensorConfiguration.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/homeassistant/SensorConfiguration.kt
@@ -71,7 +71,7 @@ private fun JsonWriter.writeImage(
     name("image_topic")
     value(imageTopic)
     name("content_type")
-    value("image/jpeg")
+    value("image/png")
     name("device")
     writeDeviceInfo(deviceId)
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/homeassistant/SensorConfiguration.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/homeassistant/SensorConfiguration.kt
@@ -58,6 +58,26 @@ private fun JsonWriter.writeSensor(
     endObject()
 }
 
+private fun JsonWriter.writeImage(
+    deviceId: Int,
+    imageTopic: String
+) {
+    beginObject()
+
+    name("name")
+    value("Media Artwork")
+    name("unique_id")
+    value("mediasession_${deviceId}_media_artwork")
+    name("image_topic")
+    value(imageTopic)
+    name("content_type")
+    value("image/jpeg")
+    name("device")
+    writeDeviceInfo(deviceId)
+
+    endObject()
+}
+
 fun createSensorDiscoveryConfiguration(deviceId: Int, sensor: Sensor, sensorTopic: String): String {
     val writer = StringWriter()
     JsonWriter(writer).use {
@@ -69,6 +89,17 @@ fun createSensorDiscoveryConfiguration(deviceId: Int, sensor: Sensor, sensorTopi
             sensorTopic = sensorTopic,
             sensorDeviceClass = sensor.deviceClass,
             sensorUnitOfMeasurement = sensor.unitOfMeasurement
+        )
+    }
+    return writer.toString()
+}
+
+fun createImageDiscoveryConfiguration(deviceId: Int, imageTopic: String): String {
+    val writer = StringWriter()
+    JsonWriter(writer).use {
+        it.writeImage(
+            deviceId = deviceId,
+            imageTopic = imageTopic
         )
     }
     return writer.toString()

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/KMQTTClient.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/KMQTTClient.kt
@@ -53,7 +53,7 @@ class KMQTTClient(
         }
     }
 
-    override suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: String) {
+    override suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: ByteArray) {
         withContext(dispatcher) {
             var client = currentClient?.takeIf { it.isRunning() }
             if (client != null) {
@@ -77,12 +77,12 @@ class KMQTTClient(
         }
     }
 
-    private fun MQTTClient.publishAndStep(qosLevel: MQTTQoSLevel, topic: String, payload: String) {
+    private fun MQTTClient.publishAndStep(qosLevel: MQTTQoSLevel, topic: String, payload: ByteArray) {
         publish(
             true,
             Qos.entries[qosLevel.ordinal],
             topic,
-            payload.encodeToByteArray().toUByteArray()
+            payload.toUByteArray()
         )
         step()
         check(isRunning()) { "MQTT connection lost while publishing" }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClient.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClient.kt
@@ -10,7 +10,11 @@ interface MQTTPublishClient {
      * Connect if not currently connected, and publish.
      * Throw an Exception in case of any failure.
      */
-    suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: String)
+    suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: ByteArray)
+
+    suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: String) {
+        connectAndPublish(qosLevel, topic, payload.encodeToByteArray())
+    }
 
     /**
      * Disconnect if currently connected.

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClientExt.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClientExt.kt
@@ -27,3 +27,22 @@ suspend fun MQTTPublishClient.tryConnectAndPublish(
         false
     }
 }
+
+/**
+ * Binary variant of [tryConnectAndPublish].
+ * Swallows exceptions and returns true in case of success.
+ */
+suspend fun MQTTPublishClient.tryConnectAndPublish(
+    qosLevel: MQTTQoSLevel,
+    topic: String,
+    payload: ByteArray
+): Boolean {
+    return try {
+        connectAndPublish(qosLevel, topic, payload)
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
+        false
+    }
+}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkRepository.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkRepository.kt
@@ -1,0 +1,78 @@
+package be.digitalia.mediasession2mqtt.mqttmediaplayer
+
+import android.content.Context
+import android.net.http.HttpResponseCache
+import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
+import be.digitalia.mediasession2mqtt.mediasession.metadataFlow
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.stateIn
+import java.io.File
+import java.io.IOException
+
+@Inject
+@SingleIn(AppScope::class)
+class ArtworkRepository(
+    context: Context,
+    currentMediaControllerDetector: CurrentMediaControllerDetector
+) {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    init {
+        installHttpCache(context)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val artwork: StateFlow<ByteArray?> =
+        currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
+            mediaController?.metadataFlow ?: flowOf(null)
+        }
+            .map { metadata -> metadata.toArtworkSource() }
+            .distinctUntilChanged()
+            .mapLatest { source -> resolveArtworkPng(source) }
+            .buffer(Channel.RENDEZVOUS)
+            .distinctUntilChanged { previous, current -> previous.contentEquals(current) }
+            .stateIn(
+                scope = coroutineScope,
+                started = SharingStarted.WhileSubscribed(
+                    stopTimeoutMillis = ARTWORK_SHARING_STOP_TIMEOUT_MILLIS,
+                    replayExpirationMillis = 0L
+                ),
+                initialValue = null
+            )
+
+    companion object {
+        private const val ARTWORK_SHARING_STOP_TIMEOUT_MILLIS = 5000L
+        private const val HTTP_CACHE_MAX_BYTES = 20L * 1024L * 1024L
+        private const val HTTP_CACHE_DIRECTORY = "artwork_http"
+
+        private fun installHttpCache(context: Context) {
+            synchronized(HttpResponseCache::class.java) {
+                if (HttpResponseCache.getInstalled() == null) {
+                    try {
+                        HttpResponseCache.install(
+                            File(context.cacheDir, HTTP_CACHE_DIRECTORY),
+                            HTTP_CACHE_MAX_BYTES
+                        )
+                    } catch (_: IOException) {
+                        // Artwork downloads still work when the optional cache is unavailable.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkRepository.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkRepository.kt
@@ -24,6 +24,11 @@ import kotlinx.coroutines.flow.stateIn
 import java.io.File
 import java.io.IOException
 
+private data class ArtworkRequest(
+    val source: ArtworkSource,
+    val cacheKey: String
+)
+
 @Inject
 @SingleIn(AppScope::class)
 class ArtworkRepository(
@@ -39,11 +44,23 @@ class ArtworkRepository(
     @OptIn(ExperimentalCoroutinesApi::class)
     val artwork: StateFlow<ByteArray?> =
         currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
-            mediaController?.metadataFlow ?: flowOf(null)
+            when (mediaController) {
+                null -> flowOf(
+                    ArtworkRequest(
+                        source = ArtworkSource.None,
+                        cacheKey = ""
+                    )
+                )
+                else -> mediaController.metadataFlow.map { metadata ->
+                    ArtworkRequest(
+                        source = metadata.toArtworkSource(),
+                        cacheKey = metadata.toArtworkCacheKey(mediaController.packageName)
+                    )
+                }
+            }
         }
-            .map { metadata -> metadata.toArtworkSource() }
             .distinctUntilChanged()
-            .mapLatest { source -> resolveArtworkPng(source) }
+            .mapLatest { request -> resolveArtworkPng(request.source) }
             .buffer(Channel.RENDEZVOUS)
             .distinctUntilChanged { previous, current -> previous.contentEquals(current) }
             .stateIn(

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
@@ -6,97 +6,98 @@ import android.media.MediaMetadata
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
 
-private const val MAX_ARTWORK_DIMENSION = 800
 private const val MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024
 private const val CONNECT_TIMEOUT_MILLIS = 10_000
 private const val READ_TIMEOUT_MILLIS = 10_000
 
+private val ARTWORK_BITMAP_KEYS = arrayOf(
+    MediaMetadata.METADATA_KEY_DISPLAY_ICON,
+    MediaMetadata.METADATA_KEY_ART,
+    MediaMetadata.METADATA_KEY_ALBUM_ART
+)
+
+private val ARTWORK_URI_KEYS = arrayOf(
+    MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI,
+    MediaMetadata.METADATA_KEY_ART_URI,
+    MediaMetadata.METADATA_KEY_ALBUM_ART_URI
+)
+
+sealed interface ArtworkSource {
+    data object None : ArtworkSource
+    data class BitmapValue(val value: Bitmap) : ArtworkSource
+    data class Url(val value: URI) : ArtworkSource
+}
+
 /**
- * Build a cheap key that changes whenever the current media or its advertised artwork changes.
+ * Select the preferred artwork before using it as the cache key.
  */
-fun MediaMetadata?.toArtworkCacheKey(packageName: String): String {
+fun MediaMetadata?.toArtworkSource(): ArtworkSource {
     if (this == null) {
-        return packageName
+        return ArtworkSource.None
     }
-    return listOf(
-        packageName,
-        getString(MediaMetadata.METADATA_KEY_MEDIA_ID).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_TITLE).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_ARTIST).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_ALBUM).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_ALBUM_ART_URI).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_ART_URI).orEmpty(),
-        getString(MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI).orEmpty()
-    ).joinToString("\u0000")
+
+    return ARTWORK_BITMAP_KEYS.firstNotNullOfOrNull { key ->
+        getBitmap(key)?.let { ArtworkSource.BitmapValue(it) }
+    } ?: ARTWORK_URI_KEYS.firstNotNullOfOrNull { key ->
+        getString(key)?.let { value ->
+            runCatching { URI(value) }.getOrNull()?.takeIf { uri ->
+                uri.host != null && (
+                    uri.scheme.equals("http", ignoreCase = true) ||
+                        uri.scheme.equals("https", ignoreCase = true)
+                    )
+            }
+        }?.let { ArtworkSource.Url(it) }
+    } ?: ArtworkSource.None
 }
 
 /**
- * Resolve the current MediaSession artwork and normalize it to JPEG bytes.
+ * Resolve the selected MediaSession artwork and encode it as lossless PNG bytes.
  */
-suspend fun resolveArtworkJpeg(metadata: MediaMetadata?): ByteArray =
+suspend fun resolveArtworkPng(source: ArtworkSource): ByteArray =
     withContext(Dispatchers.IO) {
-        if (metadata == null) {
-            return@withContext ByteArray(0)
+        when (source) {
+            ArtworkSource.None -> ByteArray(0)
+            is ArtworkSource.BitmapValue -> source.value.toPng()
+            is ArtworkSource.Url -> downloadBitmap(source.value)?.let { bitmap ->
+                try {
+                    bitmap.toPng()
+                } finally {
+                    bitmap.recycle()
+                }
+            } ?: ByteArray(0)
         }
-
-        metadata.firstArtworkBitmap()?.let { bitmap ->
-            return@withContext bitmap.toJpeg()
-        }
-
-        metadata.firstArtworkUri()?.let { uri ->
-            downloadBitmap(uri)?.let { bitmap ->
-                return@withContext bitmap.toJpeg()
-            }
-        }
-
-        ByteArray(0)
     }
 
-private fun MediaMetadata.firstArtworkBitmap(): Bitmap? {
-    return runCatching { getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART) }.getOrNull()
-        ?: runCatching { getBitmap(MediaMetadata.METADATA_KEY_ART) }.getOrNull()
-        ?: runCatching { getBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON) }.getOrNull()
-}
-
-private fun MediaMetadata.firstArtworkUri(): String? {
-    return sequenceOf(
-        MediaMetadata.METADATA_KEY_ALBUM_ART_URI,
-        MediaMetadata.METADATA_KEY_ART_URI,
-        MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI
-    ).mapNotNull { key -> getString(key) }
-        .firstOrNull { value ->
-            runCatching {
-                val scheme = URI(value).scheme
-                scheme == "https" || scheme == "http"
-            }.getOrDefault(false)
-        }
-}
-
-private fun downloadBitmap(url: String): Bitmap? {
-    val bytes = httpGet(url) ?: return null
+private suspend fun downloadBitmap(uri: URI): Bitmap? {
+    val bytes = httpGet(uri) ?: return null
     return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
 }
 
-private fun httpGet(url: String): ByteArray? {
-    val connection = (URI(url).toURL().openConnection() as? HttpURLConnection) ?: return null
+private suspend fun httpGet(uri: URI): ByteArray? {
+    val connection = try {
+        uri.toURL().openConnection() as? HttpURLConnection
+    } catch (_: IOException) {
+        null
+    } ?: return null
+
     return try {
         connection.connectTimeout = CONNECT_TIMEOUT_MILLIS
         connection.readTimeout = READ_TIMEOUT_MILLIS
         connection.instanceFollowRedirects = true
+        connection.useCaches = true
         connection.setRequestProperty("User-Agent", "MediaSession2MQTT")
         connection.connect()
-        if (connection.responseCode !in 200..299) {
+
+        if (connection.responseCode !in 200..299 ||
+            connection.contentLength > MAX_DOWNLOAD_BYTES
+        ) {
             return null
         }
-        connection.contentLengthLong.takeIf { it >= 0 }?.let { contentLength ->
-            if (contentLength > MAX_DOWNLOAD_BYTES) {
-                return null
-            }
-        }
+
         connection.inputStream.use { input ->
             val output = ByteArrayOutputStream()
             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
@@ -114,31 +115,18 @@ private fun httpGet(url: String): ByteArray? {
             }
             output.toByteArray()
         }
-    } catch (_: Exception) {
+    } catch (_: IOException) {
         null
     } finally {
         connection.disconnect()
     }
 }
 
-private fun Bitmap.toJpeg(): ByteArray {
-    val normalized = if (width <= MAX_ARTWORK_DIMENSION && height <= MAX_ARTWORK_DIMENSION) {
-        this
-    } else {
-        val scale = MAX_ARTWORK_DIMENSION.toFloat() / maxOf(width, height)
-        Bitmap.createScaledBitmap(
-            this,
-            (width * scale).toInt().coerceAtLeast(1),
-            (height * scale).toInt().coerceAtLeast(1),
-            true
-        )
-    }
-
-    return ByteArrayOutputStream().use { output ->
-        normalized.compress(Bitmap.CompressFormat.JPEG, 90, output)
-        if (normalized !== this) {
-            normalized.recycle()
+private fun Bitmap.toPng(): ByteArray =
+    ByteArrayOutputStream().use { output ->
+        if (compress(Bitmap.CompressFormat.PNG, 100, output)) {
+            output.toByteArray()
+        } else {
+            ByteArray(0)
         }
-        output.toByteArray()
     }
-}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
@@ -1,0 +1,144 @@
+package be.digitalia.mediasession2mqtt.mqttmediaplayer
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.media.MediaMetadata
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.URI
+
+private const val MAX_ARTWORK_DIMENSION = 800
+private const val MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024
+private const val CONNECT_TIMEOUT_MILLIS = 10_000
+private const val READ_TIMEOUT_MILLIS = 10_000
+
+/**
+ * Build a cheap key that changes whenever the current media or its advertised artwork changes.
+ */
+fun MediaMetadata?.toArtworkCacheKey(packageName: String): String {
+    if (this == null) {
+        return packageName
+    }
+    return listOf(
+        packageName,
+        getString(MediaMetadata.METADATA_KEY_MEDIA_ID).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_TITLE).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ARTIST).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ALBUM).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ALBUM_ART_URI).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ART_URI).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI).orEmpty()
+    ).joinToString("\u0000")
+}
+
+/**
+ * Resolve the current MediaSession artwork and normalize it to JPEG bytes.
+ */
+suspend fun resolveArtworkJpeg(metadata: MediaMetadata?): ByteArray =
+    withContext(Dispatchers.IO) {
+        if (metadata == null) {
+            return@withContext ByteArray(0)
+        }
+
+        metadata.firstArtworkBitmap()?.let { bitmap ->
+            return@withContext bitmap.toJpeg()
+        }
+
+        metadata.firstArtworkUri()?.let { uri ->
+            downloadBitmap(uri)?.let { bitmap ->
+                return@withContext bitmap.toJpeg()
+            }
+        }
+
+        ByteArray(0)
+    }
+
+private fun MediaMetadata.firstArtworkBitmap(): Bitmap? {
+    return runCatching { getBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART) }.getOrNull()
+        ?: runCatching { getBitmap(MediaMetadata.METADATA_KEY_ART) }.getOrNull()
+        ?: runCatching { getBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON) }.getOrNull()
+}
+
+private fun MediaMetadata.firstArtworkUri(): String? {
+    return sequenceOf(
+        MediaMetadata.METADATA_KEY_ALBUM_ART_URI,
+        MediaMetadata.METADATA_KEY_ART_URI,
+        MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI
+    ).mapNotNull { key -> getString(key) }
+        .firstOrNull { value ->
+            runCatching {
+                val scheme = URI(value).scheme
+                scheme == "https" || scheme == "http"
+            }.getOrDefault(false)
+        }
+}
+
+private fun downloadBitmap(url: String): Bitmap? {
+    val bytes = httpGet(url) ?: return null
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+}
+
+private fun httpGet(url: String): ByteArray? {
+    val connection = (URI(url).toURL().openConnection() as? HttpURLConnection) ?: return null
+    return try {
+        connection.connectTimeout = CONNECT_TIMEOUT_MILLIS
+        connection.readTimeout = READ_TIMEOUT_MILLIS
+        connection.instanceFollowRedirects = true
+        connection.setRequestProperty("User-Agent", "MediaSession2MQTT")
+        connection.connect()
+        if (connection.responseCode !in 200..299) {
+            return null
+        }
+        connection.contentLengthLong.takeIf { it >= 0 }?.let { contentLength ->
+            if (contentLength > MAX_DOWNLOAD_BYTES) {
+                return null
+            }
+        }
+        connection.inputStream.use { input ->
+            val output = ByteArrayOutputStream()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            var total = 0
+            while (true) {
+                val count = input.read(buffer)
+                if (count < 0) {
+                    break
+                }
+                total += count
+                if (total > MAX_DOWNLOAD_BYTES) {
+                    return null
+                }
+                output.write(buffer, 0, count)
+            }
+            output.toByteArray()
+        }
+    } catch (_: Exception) {
+        null
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private fun Bitmap.toJpeg(): ByteArray {
+    val normalized = if (width <= MAX_ARTWORK_DIMENSION && height <= MAX_ARTWORK_DIMENSION) {
+        this
+    } else {
+        val scale = MAX_ARTWORK_DIMENSION.toFloat() / maxOf(width, height)
+        Bitmap.createScaledBitmap(
+            this,
+            (width * scale).toInt().coerceAtLeast(1),
+            (height * scale).toInt().coerceAtLeast(1),
+            true
+        )
+    }
+
+    return ByteArrayOutputStream().use { output ->
+        normalized.compress(Bitmap.CompressFormat.JPEG, 90, output)
+        if (normalized !== this) {
+            normalized.recycle()
+        }
+        output.toByteArray()
+    }
+}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqttmediaplayer/ArtworkResolver.kt
@@ -33,7 +33,24 @@ sealed interface ArtworkSource {
 }
 
 /**
- * Select the preferred artwork before using it as the cache key.
+ * Build a cheap key that changes whenever the current media changes.
+ */
+fun MediaMetadata?.toArtworkCacheKey(packageName: String): String {
+    if (this == null) {
+        return packageName
+    }
+    return listOf(
+        packageName,
+        getString(MediaMetadata.METADATA_KEY_MEDIA_ID).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_TITLE).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_DISPLAY_TITLE).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ARTIST).orEmpty(),
+        getString(MediaMetadata.METADATA_KEY_ALBUM).orEmpty()
+    ).joinToString("\u0000")
+}
+
+/**
+ * Select the preferred artwork source.
  */
 fun MediaMetadata?.toArtworkSource(): ArtworkSource {
     if (this == null) {

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/ui/ArtworkStatusPreference.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/ui/ArtworkStatusPreference.kt
@@ -1,0 +1,30 @@
+package be.digitalia.mediasession2mqtt.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.preference.Preference
+import android.util.AttributeSet
+import android.view.View
+import android.widget.ImageView
+import be.digitalia.mediasession2mqtt.R
+
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class ArtworkStatusPreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {
+    private var artwork: Bitmap? = null
+
+    init {
+        layoutResource = R.layout.preference_artwork_status
+    }
+
+    fun setArtwork(bitmap: Bitmap?) {
+        artwork = bitmap
+        notifyChanged()
+    }
+
+    override fun onBindView(view: View) {
+        super.onBindView(view)
+        val artworkView = view.findViewById<ImageView>(R.id.status_artwork)
+        artworkView.setImageBitmap(artwork)
+        artworkView.visibility = if (artwork == null) View.GONE else View.VISIBLE
+    }
+}

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
@@ -16,10 +16,9 @@ import be.digitalia.mediasession2mqtt.BuildConfig
 import be.digitalia.mediasession2mqtt.R
 import be.digitalia.mediasession2mqtt.inject.appGraph
 import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
-import be.digitalia.mediasession2mqtt.mediasession.metadataFlow
 import be.digitalia.mediasession2mqtt.mqtt.MQTTPublishClient
 import be.digitalia.mediasession2mqtt.mqtt.testConnection
-import be.digitalia.mediasession2mqtt.mqttmediaplayer.resolveArtworkJpeg
+import be.digitalia.mediasession2mqtt.mqttmediaplayer.ArtworkRepository
 import be.digitalia.mediasession2mqtt.settings.PreferenceKeys
 import be.digitalia.mediasession2mqtt.settings.SettingsProvider
 import dev.zacsweers.metro.Inject
@@ -32,12 +31,13 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @SuppressLint("ExportedPreferenceActivity")
 class SettingsActivity : PreferenceActivity() {
@@ -48,6 +48,8 @@ class SettingsActivity : PreferenceActivity() {
     private lateinit var mqttClientFactory: MQTTPublishClient.Factory
     @Inject
     private lateinit var currentMediaControllerDetector: CurrentMediaControllerDetector
+    @Inject
+    private lateinit var artworkRepository: ArtworkRepository
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val statusSummary: Flow<CharSequence> by lazy(LazyThreadSafetyMode.NONE) {
@@ -202,18 +204,14 @@ class SettingsActivity : PreferenceActivity() {
             }
         }
         coroutineScope.launch {
-            currentMediaControllerDetector.currentMediaController
-                .flatMapLatest { mediaController ->
-                    mediaController?.metadataFlow ?: flowOf(null)
-                }
-                .mapLatest { metadata ->
-                    resolveArtworkJpeg(metadata)
-                        .takeIf { it.isNotEmpty() }
+            artworkRepository.artwork.collectLatest { artwork ->
+                val bitmap = withContext(Dispatchers.Default) {
+                    artwork
+                        ?.takeIf { it.isNotEmpty() }
                         ?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
                 }
-                .collect { bitmap ->
-                    statusPreference.setArtwork(bitmap)
-                }
+                statusPreference.setArtwork(bitmap)
+            }
         }
     }
 }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
@@ -5,6 +5,7 @@ package be.digitalia.mediasession2mqtt.ui
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.preference.EditTextPreference
 import android.preference.ListPreference
@@ -15,8 +16,10 @@ import be.digitalia.mediasession2mqtt.BuildConfig
 import be.digitalia.mediasession2mqtt.R
 import be.digitalia.mediasession2mqtt.inject.appGraph
 import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
+import be.digitalia.mediasession2mqtt.mediasession.metadataFlow
 import be.digitalia.mediasession2mqtt.mqtt.MQTTPublishClient
 import be.digitalia.mediasession2mqtt.mqtt.testConnection
+import be.digitalia.mediasession2mqtt.mqttmediaplayer.resolveArtworkJpeg
 import be.digitalia.mediasession2mqtt.settings.PreferenceKeys
 import be.digitalia.mediasession2mqtt.settings.SettingsProvider
 import dev.zacsweers.metro.Inject
@@ -33,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 
 @SuppressLint("ExportedPreferenceActivity")
@@ -188,12 +192,28 @@ class SettingsActivity : PreferenceActivity() {
         super.onStop()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun setupStatus(coroutineScope: CoroutineScope) {
-        val statusPreference = findPreference(PreferenceKeys.STATUS)
+        val statusPreference = findPreference(PreferenceKeys.STATUS) as ArtworkStatusPreference
+
         coroutineScope.launch {
             statusSummary.collect {
                 statusPreference.summary = it
             }
+        }
+        coroutineScope.launch {
+            currentMediaControllerDetector.currentMediaController
+                .flatMapLatest { mediaController ->
+                    mediaController?.metadataFlow ?: flowOf(null)
+                }
+                .mapLatest { metadata ->
+                    resolveArtworkJpeg(metadata)
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+                }
+                .collect { bitmap ->
+                    statusPreference.setArtwork(bitmap)
+                }
         }
     }
 }

--- a/app/src/main/res/layout/preference_artwork_status.xml
+++ b/app/src/main/res/layout/preference_artwork_status.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="64dp"
+    android:orientation="vertical"
+    android:paddingStart="12dp"
+    android:paddingTop="10dp"
+    android:paddingEnd="12dp"
+    android:paddingBottom="10dp">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItem" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/status_artwork"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@android:id/summary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textAppearance="?android:attr/textAppearanceListItemSecondary" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -60,7 +60,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_info">
-        <Preference
+        <be.digitalia.mediasession2mqtt.ui.ArtworkStatusPreference
             android:key="status"
             android:title="@string/settings_status" />
         <Preference


### PR DESCRIPTION
Send artwork jpeg as bytearray via MQTT.
Added preview to "Status" section.

JPEG seems to me the most optimal target format.

Implements #17 


<img width="300" alt="Screenshot 2026-08-27 at 18 34 00" src="https://github.com/user-attachments/assets/037e61ff-a42e-4938-aa6a-0595395dd3dc" />
<br/>

<img width="300"  alt="Screenshot 2026-08-27 at 18 34 15" src="https://github.com/user-attachments/assets/b01810e4-24ff-4ffb-9fc8-c722c59186b4" />
<br/>


<img width="300" alt="Screenshot 2026-08-27 at 18 37 17" src="https://github.com/user-attachments/assets/cc667e76-b403-4eab-b148-98e155e10882" />

