### PR TITLE
feat: add media control over MQTT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ local.properties
 
 # Kotlin
 .kotlin
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -113,9 +113,30 @@ After rebooting your TCL TV, you should see the session status being updated on 
 
 This app provides an integration for Home Assistant since version 1.1.0. Check the box "Enable Home Assistant integration" in the settings screen and the MQTT Discovery configuration will also be published, allowing Home Assistant to detect and configure MediaSession2MQTT as a new device automatically.
 
+## Home Assistant media player
+
+This repository also contains the `mediasession2mqtt_player` Home Assistant custom integration, installable through HACS. It communicates directly with MediaSession2MQTT over MQTT; the Home Assistant Android Companion app is not required.
+
+In MediaSession2MQTT, configure the MQTT broker and enable **Allow media control**. Media control is disabled by default. On Android 6 and newer, when control is enabled the app checks whether battery optimization can suspend it in the background. If the app is already exempt, nothing is shown; otherwise Android asks whether to allow unrestricted background operation.
+
+[![Open your Home Assistant instance and open this repository in HACS.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=qweritos&repository=MediaSession2MQTT&category=integration)
+
+Alternatively, add `https://github.com/qweritos/MediaSession2MQTT` in **HACS → Integrations → Custom repositories** with category **Integration**. Install **MediaSession2MQTT Player**, restart Home Assistant, then add:
+
+```yaml
+media_player:
+  - platform: mediasession2mqtt_player
+    name: Android Media
+    device_id: 1
+```
+
+`device_id` must match the device id configured in the Android app. The helper subscribes directly to `mediaSession/{deviceId}/...` state topics and publishes controls to `mediaSession/{deviceId}/command/...`. No per-sensor entity configuration is required.
+
+The helper exposes only controls reported as supported by the active Android MediaSession. Depending on the player, these can include play, pause, stop, next, previous, seek, volume set/step and mute.
+
 ## The MQTT API
 
-This application is designed to only push state messages and not listen to MQTT commands. The MQTT connection is kept open as long as possible and no keepalive packets are sent. If the connection gets interrupted for any reason, it will be automatically re-established lazily when the next MQTT message needs to be published.
+The application publishes MediaSession state and listens for non-retained MQTT media-control commands. The MQTT connection is kept open as long as possible and is automatically re-established when necessary.
 
 The application publishes the following 3 topics to the MQTT broker (replace `{deviceId}` with your actual device id which is `1` by default):
 
@@ -154,6 +175,42 @@ Note that many applications don't report any title, for example: Netflix, Disney
 ### mediaSession/{deviceId}/mediaDuration
 
 The duration of the currently playing or paused media in milliseconds, or an empty String (`""`) if no media is currently playing or paused or the duration is unavailable.
+
+### mediaSession/{deviceId}/playbackActions
+
+The Android `PlaybackState.actions` bitmask reported by the active MediaSession. Consumers can use it to expose only controls supported by the current player.
+
+### mediaSession/{deviceId}/volumeLevel
+
+The current MediaSession volume normalized to the range `0.0` to `1.0`, or an empty string when unavailable.
+
+### mediaSession/{deviceId}/volumeControl
+
+The MediaSession volume-control type: `absolute`, `relative`, `fixed`, or an empty string when unavailable.
+
+### mediaSession/{deviceId}/volumeMuted
+
+Whether the active output is currently muted. Device-side media volume and mute changes are published back to MQTT so Home Assistant stays synchronized with hardware volume buttons and the Android system UI.
+
+### mediaSession/{deviceId}/mediaControlEnabled
+
+`true` when **Allow media control** is enabled in the Android app, otherwise `false`. The Home Assistant helper uses this to hide control features when remote control is disabled.
+
+### mediaSession/{deviceId}/seek
+
+Legacy seek command. Publish an absolute playback position in milliseconds to seek the active MediaSession. Messages must not be retained.
+
+### mediaSession/{deviceId}/command/{command}
+
+Publish a non-retained message to one of these command topics:
+
+- `play`, `pause`, `playPause`, `stop`
+- `next`, `previous`
+- `fastForward`, `rewind`
+- `seek` — payload is the absolute position in milliseconds
+- `volume` — payload is a normalized volume from `0.0` to `1.0`
+- `volumeUp`, `volumeDown`
+- `mute`, `unmute`
 
 ## A note about the Netflix app
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
         android:name=".MainApplication"

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/MainWorker.kt
@@ -1,11 +1,20 @@
 package be.digitalia.mediasession2mqtt
 
 import android.content.Context
+import android.database.ContentObserver
+import android.media.AudioManager
+import android.media.VolumeProvider
+import android.media.session.MediaController
 import android.media.session.PlaybackState
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
 import be.digitalia.mediasession2mqtt.homeassistant.Sensor
 import be.digitalia.mediasession2mqtt.homeassistant.createSensorDiscoveryConfiguration
 import be.digitalia.mediasession2mqtt.mediasession.CurrentMediaControllerDetector
 import be.digitalia.mediasession2mqtt.mediasession.metadataFlow
+import be.digitalia.mediasession2mqtt.mediasession.playbackInfoFlow
 import be.digitalia.mediasession2mqtt.mediasession.playbackStateFlow
 import be.digitalia.mediasession2mqtt.mqtt.MQTTPublishClient
 import be.digitalia.mediasession2mqtt.mqtt.MQTTQoSLevel
@@ -20,23 +29,30 @@ import be.digitalia.mediasession2mqtt.service.MediaSessionListenerService
 import be.digitalia.mediasession2mqtt.settings.SettingsProvider
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.roundToInt
 
 @Inject
 class MainWorker(
@@ -46,6 +62,19 @@ class MainWorker(
     private val mqttClientFactory: MQTTPublishClient.Factory
 ) {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val volumeRefreshFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    private val localVolumeChangeFlow: Flow<Int> = callbackFlow {
+        val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                trySend(audioManager.getStreamVolume(AudioManager.STREAM_MUSIC))
+            }
+        }
+        context.contentResolver.registerContentObserver(Settings.System.CONTENT_URI, true, observer)
+        trySend(audioManager.getStreamVolume(AudioManager.STREAM_MUSIC))
+        awaitClose { context.contentResolver.unregisterContentObserver(observer) }
+    }.conflate().distinctUntilChanged()
 
     private val applicationIdFlow: Flow<String> =
         currentMediaControllerDetector.currentMediaController.map { mediaController ->
@@ -83,23 +112,167 @@ class MainWorker(
             }
         }.buffer(Channel.RENDEZVOUS)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val playbackActionsFlow: Flow<Long> =
+        currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
+            when (mediaController) {
+                null -> flowOf(0L)
+                else -> mediaController.playbackStateFlow.map { it?.actions ?: 0L }
+            }
+        }.distinctUntilChanged()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val playbackInfoFlow: Flow<MediaController.PlaybackInfo?> =
+        currentMediaControllerDetector.currentMediaController.flatMapLatest { mediaController ->
+            when (mediaController) {
+                null -> flowOf(null)
+                else -> mediaController.playbackInfoFlow
+            }
+        }.distinctUntilChanged { old, new ->
+            old?.currentVolume == new?.currentVolume &&
+                old?.maxVolume == new?.maxVolume &&
+                old?.volumeControl == new?.volumeControl
+        }
+
     private suspend fun monitorSettings() {
         settingsProvider.connectionSettings.collectLatest { connectionSettings ->
             if (connectionSettings != null) {
                 val client = mqttClientFactory.create(connectionSettings)
+                val subscribeClient = mqttClientFactory.create(connectionSettings)
                 try {
                     settingsProvider.messageSettings.collectLatest { (qosLevel, deviceId) ->
                         coroutineScope {
+                            launch {
+                                settingsProvider.isMediaControlEnabled.collectLatest { isEnabled ->
+                                    if (isEnabled) {
+                                        listenForMediaCommands(subscribeClient, qosLevel, deviceId)
+                                    } else {
+                                        subscribeClient.disconnectQuietly()
+                                    }
+                                }
+                            }
                             launch { publishHassConfigurationIfEnabled(client, qosLevel, deviceId) }
                             launch { publishApplicationId(client, qosLevel, deviceId) }
                             launch { publishPlaybackState(client, qosLevel, deviceId) }
+                            launch { publishPlaybackActions(client, qosLevel, deviceId) }
+                            launch { publishPlaybackInfo(client, qosLevel, deviceId) }
+                            launch { publishMediaControlEnabled(client, qosLevel, deviceId) }
                             launch { publishMediaMetadata(client, qosLevel, deviceId) }
                         }
                     }
                 } finally {
                     client.disconnectQuietly()
+                    subscribeClient.disconnectQuietly()
                 }
             }
+        }
+    }
+
+    private suspend fun listenForMediaCommands(
+        client: MQTTPublishClient,
+        qosLevel: MQTTQoSLevel,
+        deviceId: Int
+    ) {
+        while (true) {
+            try {
+                client.listen(
+                    qosLevel = qosLevel,
+                    topicFilter = "$ROOT_TOPIC/$deviceId/#"
+                ) { topic, payload ->
+                    handleMediaCommand(deviceId, topic, payload)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                client.disconnectQuietly()
+                delay(MQTT_COMMAND_RECONNECT_DELAY_MILLIS)
+            }
+        }
+    }
+
+    private fun handleMediaCommand(deviceId: Int, topic: String, payload: String) {
+        val controller = currentMediaControllerDetector.currentMediaController.value ?: return
+        val commandPrefix = "$ROOT_TOPIC/$deviceId/$COMMAND_SUB_TOPIC/"
+
+        // Backward compatibility with the original seek-only command topic.
+        if (topic == "$ROOT_TOPIC/$deviceId/$SEEK_SUB_TOPIC") {
+            payload.toLongOrNull()?.takeIf { it >= 0L }?.let(controller.transportControls::seekTo)
+            return
+        }
+
+        if (!topic.startsWith(commandPrefix)) return
+        when (topic.removePrefix(commandPrefix)) {
+            "play" -> controller.transportControls.play()
+            "pause" -> controller.transportControls.pause()
+            "playPause" -> {
+                if (controller.playbackState?.state == PlaybackState.STATE_PLAYING) {
+                    controller.transportControls.pause()
+                } else {
+                    controller.transportControls.play()
+                }
+            }
+            "stop" -> controller.transportControls.stop()
+            "next" -> controller.transportControls.skipToNext()
+            "previous" -> controller.transportControls.skipToPrevious()
+            "fastForward" -> controller.transportControls.fastForward()
+            "rewind" -> controller.transportControls.rewind()
+            "seek" -> payload.toLongOrNull()?.takeIf { it >= 0L }?.let(controller.transportControls::seekTo)
+            "volume" -> {
+                setVolume(controller, payload)
+                volumeRefreshFlow.tryEmit(Unit)
+            }
+            "volumeUp" -> {
+                adjustVolume(controller, AudioManager.ADJUST_RAISE)
+                volumeRefreshFlow.tryEmit(Unit)
+            }
+            "volumeDown" -> {
+                adjustVolume(controller, AudioManager.ADJUST_LOWER)
+                volumeRefreshFlow.tryEmit(Unit)
+            }
+            "mute" -> {
+                adjustVolume(controller, AudioManager.ADJUST_MUTE)
+                volumeRefreshFlow.tryEmit(Unit)
+            }
+            "unmute" -> {
+                adjustVolume(controller, AudioManager.ADJUST_UNMUTE)
+                volumeRefreshFlow.tryEmit(Unit)
+            }
+        }
+    }
+
+    private fun setVolume(controller: MediaController, payload: String) {
+        val info = controller.playbackInfo
+        if (info.volumeControl != VolumeProvider.VOLUME_CONTROL_ABSOLUTE) return
+        val normalized = payload.toFloatOrNull()?.coerceIn(0f, 1f) ?: return
+        if (info.playbackType == MediaController.PlaybackInfo.PLAYBACK_TYPE_LOCAL) {
+            val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            audioManager.setStreamVolume(
+                AudioManager.STREAM_MUSIC,
+                (normalized * maxVolume).roundToInt(),
+                0
+            )
+        } else {
+            controller.setVolumeTo((normalized * info.maxVolume).roundToInt(), 0)
+        }
+    }
+
+    private fun adjustVolume(controller: MediaController, direction: Int) {
+        val info = controller.playbackInfo
+        if (info.volumeControl == VolumeProvider.VOLUME_CONTROL_FIXED) return
+        if (info.playbackType == MediaController.PlaybackInfo.PLAYBACK_TYPE_LOCAL) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ||
+                direction != AudioManager.ADJUST_MUTE && direction != AudioManager.ADJUST_UNMUTE
+            ) {
+                audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, direction, 0)
+            } else if (direction == AudioManager.ADJUST_MUTE) {
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, 0, 0)
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ||
+            direction != AudioManager.ADJUST_MUTE && direction != AudioManager.ADJUST_UNMUTE
+        ) {
+            controller.adjustVolume(direction, 0)
+        } else if (direction == AudioManager.ADJUST_MUTE) {
+            controller.setVolumeTo(0, 0)
         }
     }
 
@@ -166,6 +339,93 @@ class MainWorker(
         }
     }
 
+    private suspend fun publishPlaybackActions(
+        client: MQTTPublishClient,
+        qosLevel: MQTTQoSLevel,
+        deviceId: Int
+    ) {
+        playbackActionsFlow.collect { actions ->
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$PLAYBACK_ACTIONS_SUB_TOPIC",
+                actions.toString()
+            )
+        }
+    }
+
+    private suspend fun publishPlaybackInfo(
+        client: MQTTPublishClient,
+        qosLevel: MQTTQoSLevel,
+        deviceId: Int
+    ) {
+        merge(
+            playbackInfoFlow,
+            volumeRefreshFlow.map {
+                currentMediaControllerDetector.currentMediaController.value?.playbackInfo
+            },
+            localVolumeChangeFlow.map {
+                currentMediaControllerDetector.currentMediaController.value?.playbackInfo
+            }
+        ).collect { info ->
+            val volumeLevel = if (info != null && info.playbackType == MediaController.PlaybackInfo.PLAYBACK_TYPE_LOCAL) {
+                val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                if (maxVolume > 0) {
+                    audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toFloat() / maxVolume
+                } else {
+                    null
+                }
+            } else if (info != null && info.maxVolume > 0) {
+                info.currentVolume.toFloat() / info.maxVolume
+            } else {
+                null
+            }
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$VOLUME_LEVEL_SUB_TOPIC",
+                volumeLevel?.toString().orEmpty()
+            )
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$VOLUME_CONTROL_SUB_TOPIC",
+                when (info?.volumeControl) {
+                    VolumeProvider.VOLUME_CONTROL_ABSOLUTE -> "absolute"
+                    VolumeProvider.VOLUME_CONTROL_RELATIVE -> "relative"
+                    VolumeProvider.VOLUME_CONTROL_FIXED -> "fixed"
+                    else -> ""
+                }
+            )
+            val muted = if (info != null && info.playbackType == MediaController.PlaybackInfo.PLAYBACK_TYPE_LOCAL) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    audioManager.isStreamMute(AudioManager.STREAM_MUSIC) ||
+                        audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
+                } else {
+                    audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
+                }
+            } else {
+                info?.let { it.currentVolume == 0 }
+            }
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$VOLUME_MUTED_SUB_TOPIC",
+                muted?.toString().orEmpty()
+            )
+        }
+    }
+
+    private suspend fun publishMediaControlEnabled(
+        client: MQTTPublishClient,
+        qosLevel: MQTTQoSLevel,
+        deviceId: Int
+    ) {
+        settingsProvider.isMediaControlEnabled.collectLatest { enabled ->
+            client.tryConnectAndPublish(
+                qosLevel,
+                "$ROOT_TOPIC/$deviceId/$MEDIA_CONTROL_ENABLED_SUB_TOPIC",
+                enabled.toString()
+            )
+        }
+    }
+
     private suspend fun publishMediaMetadata(
         client: MQTTPublishClient,
         qosLevel: MQTTQoSLevel,
@@ -210,13 +470,21 @@ class MainWorker(
     companion object {
         private const val POSITION_DRIFT_THRESHOLD_MILLIS = 1000L
         private const val AUTO_REBIND_SERVICE_DELAY_MILLIS = 2000L
+        private const val MQTT_COMMAND_RECONNECT_DELAY_MILLIS = 2000L
 
         private const val ROOT_TOPIC = "mediaSession"
         private const val APPLICATION_ID_SUB_TOPIC = "applicationId"
         private const val PLAYBACK_STATE_SUB_TOPIC = "playbackState"
         private const val PLAYBACK_POSITION_SUB_TOPIC = "playbackPosition"
+        private const val PLAYBACK_ACTIONS_SUB_TOPIC = "playbackActions"
         private const val MEDIA_TITLE_SUB_TOPIC = "mediaTitle"
         private const val MEDIA_DURATION_SUB_TOPIC = "mediaDuration"
+        private const val VOLUME_LEVEL_SUB_TOPIC = "volumeLevel"
+        private const val VOLUME_CONTROL_SUB_TOPIC = "volumeControl"
+        private const val VOLUME_MUTED_SUB_TOPIC = "volumeMuted"
+        private const val MEDIA_CONTROL_ENABLED_SUB_TOPIC = "mediaControlEnabled"
+        private const val COMMAND_SUB_TOPIC = "command"
+        private const val SEEK_SUB_TOPIC = "seek"
 
         private const val HASS_ROOT_TOPIC = "homeassistant"
         private val HASS_SENSORS = listOf(
@@ -233,6 +501,12 @@ class MainWorker(
                 subTopic = PLAYBACK_POSITION_SUB_TOPIC,
                 deviceClass = "duration",
                 unitOfMeasurement = "ms"
+            ),
+            Sensor(
+                name = "Playback Actions",
+                serializedName = "playback_actions",
+                icon = "mdi:gesture-tap",
+                subTopic = PLAYBACK_ACTIONS_SUB_TOPIC
             ),
             Sensor(
                 name = "Application Id",
@@ -253,6 +527,30 @@ class MainWorker(
                 subTopic = MEDIA_DURATION_SUB_TOPIC,
                 deviceClass = "duration",
                 unitOfMeasurement = "ms"
+            ),
+            Sensor(
+                name = "Volume Level",
+                serializedName = "volume_level",
+                icon = "mdi:volume-high",
+                subTopic = VOLUME_LEVEL_SUB_TOPIC
+            ),
+            Sensor(
+                name = "Volume Control",
+                serializedName = "volume_control",
+                icon = "mdi:volume-source",
+                subTopic = VOLUME_CONTROL_SUB_TOPIC
+            ),
+            Sensor(
+                name = "Volume Muted",
+                serializedName = "volume_muted",
+                icon = "mdi:volume-off",
+                subTopic = VOLUME_MUTED_SUB_TOPIC
+            ),
+            Sensor(
+                name = "Media Control Enabled",
+                serializedName = "media_control_enabled",
+                icon = "mdi:remote",
+                subTopic = MEDIA_CONTROL_ENABLED_SUB_TOPIC
             )
         )
     }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mediasession/MediaSessionFlows.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mediasession/MediaSessionFlows.kt
@@ -42,3 +42,18 @@ val MediaController.metadataFlow: Flow<MediaMetadata?>
             emit(metadata)
         }
     }
+
+val MediaController.playbackInfoFlow: Flow<MediaController.PlaybackInfo?>
+    get() {
+        return callbackFlow {
+            val callback = object : MediaController.Callback() {
+                override fun onAudioInfoChanged(info: MediaController.PlaybackInfo) {
+                    trySend(info)
+                }
+            }
+            registerCallback(callback)
+            awaitClose { unregisterCallback(callback) }
+        }.conflate().onStart {
+            emit(playbackInfo)
+        }
+    }

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/KMQTTClient.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/KMQTTClient.kt
@@ -3,8 +3,11 @@ package be.digitalia.mediasession2mqtt.mqtt
 import be.digitalia.mediasession2mqtt.BuildConfig
 import io.github.davidepianca98.MQTTClient
 import io.github.davidepianca98.mqtt.MQTTVersion
+import io.github.davidepianca98.mqtt.Subscription
 import io.github.davidepianca98.mqtt.packets.Qos
+import io.github.davidepianca98.mqtt.packets.mqtt.MQTTPublish
 import io.github.davidepianca98.mqtt.packets.mqttv5.ReasonCode
+import io.github.davidepianca98.mqtt.packets.mqttv5.SubscriptionOptions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.NonCancellable
@@ -19,7 +22,7 @@ class KMQTTClient(
 
     private var currentClient: MQTTClient? = null
 
-    private fun createClient(): MQTTClient {
+    private fun createClient(onPublishReceived: (MQTTPublish) -> Unit = {}): MQTTClient {
         val mqttVersion = when (connectionSettings.protocolVersion) {
             MQTTConnectionSettings.ProtocolVersion.MQTT3_1_1 -> MQTTVersion.MQTT3_1_1
             MQTTConnectionSettings.ProtocolVersion.MQTT5 -> MQTTVersion.MQTT5
@@ -39,7 +42,8 @@ class KMQTTClient(
             connackTimeout = 10,
             connectTimeout = 10,
             debugLog = BuildConfig.DEBUG,
-        ) { }.also {
+            publishReceived = onPublishReceived
+        ).also {
             currentClient = it
         }
     }
@@ -74,6 +78,44 @@ class KMQTTClient(
             client = createClient()
             ensureActive()
             client.publishAndStep(qosLevel, topic, payload)
+        }
+    }
+
+    override suspend fun listen(
+        qosLevel: MQTTQoSLevel,
+        topicFilter: String,
+        onMessage: (topic: String, payload: String) -> Unit
+    ) {
+        withContext(dispatcher) {
+            if (currentClient != null) {
+                disconnectQuietly()
+            }
+            val client = createClient { publish ->
+                if (!publish.retain) {
+                    publish.payload
+                        ?.toByteArray()
+                        ?.decodeToString()
+                        ?.let { payload -> onMessage(publish.topicName, payload) }
+                }
+            }
+            client.step()
+            ensureActive()
+            client.subscribe(
+                listOf(
+                    Subscription(
+                        topicFilter = topicFilter,
+                        options = SubscriptionOptions(qos = Qos.entries[qosLevel.ordinal])
+                    )
+                )
+            )
+            client.step()
+
+            while (client.isRunning()) {
+                ensureActive()
+                client.step()
+            }
+
+            error("MQTT subscription connection lost")
         }
     }
 

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClient.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/mqtt/MQTTPublishClient.kt
@@ -13,6 +13,16 @@ interface MQTTPublishClient {
     suspend fun connectAndPublish(qosLevel: MQTTQoSLevel, topic: String, payload: String)
 
     /**
+     * Connect, subscribe to a topic and keep receiving messages until cancelled.
+     * Throw an Exception if the connection cannot be established or is lost.
+     */
+    suspend fun listen(
+        qosLevel: MQTTQoSLevel,
+        topicFilter: String,
+        onMessage: (topic: String, payload: String) -> Unit
+    )
+
+    /**
      * Disconnect if currently connected.
      * Exceptions must be swallowed.
      * Implementation must be non-cancellable in order to properly disconnect in case of cancellation.

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/settings/PreferenceKeys.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/settings/PreferenceKeys.kt
@@ -3,6 +3,7 @@ package be.digitalia.mediasession2mqtt.settings
 object PreferenceKeys {
     const val ENABLED = "enabled"
     const val HASS_INTEGRATION_ENABLED = "hass_integration_enabled"
+    const val MEDIA_CONTROL_ENABLED = "media_control_enabled"
 
     const val PROTOCOL_VERSION = "protocol_version"
     const val HOSTNAME = "hostname"

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/settings/SettingsProvider.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/settings/SettingsProvider.kt
@@ -76,6 +76,10 @@ class SettingsProvider(context: Context) {
         get() = sharedPreferences.getAsFlow({ key -> key == PreferenceKeys.HASS_INTEGRATION_ENABLED },
             { getBoolean(PreferenceKeys.HASS_INTEGRATION_ENABLED, false) })
 
+    val isMediaControlEnabled: Flow<Boolean>
+        get() = sharedPreferences.getAsFlow({ key -> key == PreferenceKeys.MEDIA_CONTROL_ENABLED },
+            { getBoolean(PreferenceKeys.MEDIA_CONTROL_ENABLED, false) }).distinctUntilChanged()
+
     val messageSettings: Flow<MessageSettings>
         get() = sharedPreferences.getAsFlow({ key -> key == PreferenceKeys.DEVICE_ID || key == PreferenceKeys.QOS_LEVEL },
             { messageSettings }).distinctUntilChanged()

--- a/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
+++ b/app/src/main/java/be/digitalia/mediasession2mqtt/ui/SettingsActivity.kt
@@ -5,7 +5,10 @@ package be.digitalia.mediasession2mqtt.ui
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.os.Build
+import android.os.PowerManager
 import android.preference.EditTextPreference
 import android.preference.ListPreference
 import android.preference.PreferenceActivity
@@ -92,8 +95,42 @@ class SettingsActivity : PreferenceActivity() {
         setupEditTextPreferenceSimpleSummaryProvider(PreferenceKeys.DEVICE_ID, clearTextFilter)
 
         setupConnectionTest()
+        setupMediaControlPreference()
         setupNotificationListenerLink()
         populateVersion()
+    }
+
+    private fun setupMediaControlPreference() {
+        findPreference(PreferenceKeys.MEDIA_CONTROL_ENABLED)?.setOnPreferenceChangeListener { _, newValue ->
+            if (newValue == true) {
+                requestBatteryOptimizationExemptionIfNeeded()
+            }
+            true
+        }
+    }
+
+    private fun requestBatteryOptimizationExemptionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+        val powerManager = getSystemService(POWER_SERVICE) as PowerManager
+        if (powerManager.isIgnoringBatteryOptimizations(packageName)) return
+
+        val requestIntent = Intent(
+            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+            Uri.parse("package:$packageName")
+        )
+        try {
+            startActivity(requestIntent)
+        } catch (_: ActivityNotFoundException) {
+            try {
+                startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+            } catch (_: ActivityNotFoundException) {
+                Toast.makeText(
+                    this,
+                    R.string.error_battery_optimization_settings_activity_not_found,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
     }
 
     private fun setupListPreferenceSimpleSummaryProvider(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="settings_enabled">Enabled</string>
     <string name="settings_hass_integration_enabled">Enable Home Assistant integration</string>
     <string name="settings_hass_integration_enabled_summary">Publish MQTT Discovery configuration</string>
+    <string name="settings_media_control_enabled">Allow media control</string>
+    <string name="settings_media_control_enabled_summary">Accept MQTT media-control commands in the background. May increase power consumption.</string>
 
     <string name="settings_server_connection">MQTT server connection</string>
     <string name="settings_protocol_version">Protocol version</string>
@@ -55,4 +57,5 @@
     <string name="status_current_mediasession">In progress: %1$s</string>
 
     <string name="error_notification_listener_settings_activity_not_found">System notification access settings screen not found.\nPlease manually allow MediaSession2MQTT to access notifications using ADB.</string>
+    <string name="error_battery_optimization_settings_activity_not_found">Battery optimization settings screen not found.</string>
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -12,6 +12,12 @@
             android:key="hass_integration_enabled"
             android:summary="@string/settings_hass_integration_enabled_summary"
             android:title="@string/settings_hass_integration_enabled" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="enabled"
+            android:key="media_control_enabled"
+            android:summary="@string/settings_media_control_enabled_summary"
+            android:title="@string/settings_media_control_enabled" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/custom_components/mediasession2mqtt_player/__init__.py
+++ b/custom_components/mediasession2mqtt_player/__init__.py
@@ -1,0 +1,1 @@
+"""MediaSession2MQTT Home Assistant integration."""

--- a/custom_components/mediasession2mqtt_player/manifest.json
+++ b/custom_components/mediasession2mqtt_player/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "mediasession2mqtt_player",
+  "name": "MediaSession2MQTT Player",
+  "version": "0.1.0",
+  "documentation": "https://github.com/qweritos/MediaSession2MQTT#home-assistant-media-player",
+  "issue_tracker": "https://github.com/qweritos/MediaSession2MQTT/issues",
+  "codeowners": ["@qweritos"],
+  "iot_class": "local_push",
+  "dependencies": ["mqtt"],
+  "requirements": []
+}

--- a/custom_components/mediasession2mqtt_player/media_player.py
+++ b/custom_components/mediasession2mqtt_player/media_player.py
@@ -1,0 +1,334 @@
+"""Home Assistant media player backed directly by MediaSession2MQTT MQTT topics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import mqtt
+from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+    PLATFORM_SCHEMA as MEDIA_PLAYER_PLATFORM_SCHEMA,
+)
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import dt as dt_util
+
+CONF_DEVICE_ID = "device_id"
+DEFAULT_NAME = "Android Media"
+MAX_ARTWORK_BYTES = 2 * 1024 * 1024
+
+# android.media.session.PlaybackState action flags.
+ACTION_STOP = 1
+ACTION_PAUSE = 2
+ACTION_PLAY = 4
+ACTION_SKIP_TO_PREVIOUS = 16
+ACTION_SKIP_TO_NEXT = 32
+ACTION_SEEK_TO = 256
+ACTION_PLAY_PAUSE = 512
+
+PLATFORM_SCHEMA = MEDIA_PLAYER_PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_DEVICE_ID, default=1): cv.positive_int,
+    }
+)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up a MediaSession2MQTT-backed media player."""
+    async_add_entities([MediaSession2MQTTPlayer(hass, config)])
+
+
+class MediaSession2MQTTPlayer(MediaPlayerEntity):
+    """Expose MediaSession2MQTT as a native Home Assistant media player."""
+
+    _attr_should_poll = False
+    _attr_device_class = MediaPlayerDeviceClass.SPEAKER
+
+    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+        self.hass = hass
+        self._device_id = config[CONF_DEVICE_ID]
+        self._root_topic = f"mediaSession/{self._device_id}"
+        self._attr_name = config[CONF_NAME]
+        self._attr_unique_id = f"mediasession2mqtt_{self._device_id}_player"
+
+        self._playback_state: str | None = None
+        self._playback_position: float | None = None
+        self._playback_position_updated_at: datetime | None = None
+        self._playback_actions = 0
+        self._application_id: str | None = None
+        self._media_title: str | None = None
+        self._media_duration: float | None = None
+        self._volume_level: float | None = None
+        self._volume_control: str | None = None
+        self._volume_muted: bool | None = None
+        self._media_control_enabled = False
+        self._artwork_bytes: bytes | None = None
+        self._artwork_hash: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe directly to MediaSession2MQTT state topics."""
+        await super().async_added_to_hass()
+        text_topics = {
+            "playbackState": self._set_playback_state,
+            "playbackPosition": self._set_playback_position,
+            "playbackActions": self._set_playback_actions,
+            "applicationId": self._set_application_id,
+            "mediaTitle": self._set_media_title,
+            "mediaDuration": self._set_media_duration,
+            "volumeLevel": self._set_volume_level,
+            "volumeControl": self._set_volume_control,
+            "volumeMuted": self._set_volume_muted,
+            "mediaControlEnabled": self._set_media_control_enabled,
+        }
+        for subtopic, handler in text_topics.items():
+            self.async_on_remove(
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._root_topic}/{subtopic}",
+                    handler,
+                    qos=0,
+                )
+            )
+
+        self.async_on_remove(
+            await mqtt.async_subscribe(
+                self.hass,
+                f"{self._root_topic}/mediaArtwork",
+                self._set_artwork,
+                qos=0,
+                encoding=None,
+            )
+        )
+
+    @staticmethod
+    def _payload(msg: Any) -> str:
+        return str(msg.payload).strip()
+
+    @callback
+    def _set_playback_state(self, msg: Any) -> None:
+        self._playback_state = self._payload(msg) or None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_playback_position(self, msg: Any) -> None:
+        value = self._payload(msg)
+        try:
+            self._playback_position = float(value) / 1000.0 if value else None
+        except ValueError:
+            self._playback_position = None
+        self._playback_position_updated_at = dt_util.utcnow()
+        self.async_write_ha_state()
+
+    @callback
+    def _set_playback_actions(self, msg: Any) -> None:
+        try:
+            self._playback_actions = int(self._payload(msg))
+        except ValueError:
+            self._playback_actions = 0
+        self.async_write_ha_state()
+
+    @callback
+    def _set_application_id(self, msg: Any) -> None:
+        self._application_id = self._payload(msg) or None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_media_title(self, msg: Any) -> None:
+        self._media_title = self._payload(msg) or None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_media_duration(self, msg: Any) -> None:
+        value = self._payload(msg)
+        try:
+            self._media_duration = float(value) / 1000.0 if value else None
+        except ValueError:
+            self._media_duration = None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_volume_level(self, msg: Any) -> None:
+        value = self._payload(msg)
+        try:
+            self._volume_level = max(0.0, min(1.0, float(value))) if value else None
+        except ValueError:
+            self._volume_level = None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_volume_control(self, msg: Any) -> None:
+        self._volume_control = self._payload(msg) or None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_volume_muted(self, msg: Any) -> None:
+        value = self._payload(msg).lower()
+        self._volume_muted = value == "true" if value in ("true", "false") else None
+        self.async_write_ha_state()
+
+    @callback
+    def _set_media_control_enabled(self, msg: Any) -> None:
+        self._media_control_enabled = self._payload(msg).lower() == "true"
+        self.async_write_ha_state()
+
+    @callback
+    def _set_artwork(self, msg: Any) -> None:
+        payload = bytes(msg.payload)
+        if not payload or len(payload) > MAX_ARTWORK_BYTES:
+            self._artwork_bytes = None
+            self._artwork_hash = None
+        else:
+            self._artwork_bytes = payload
+            self._artwork_hash = hashlib.sha256(payload).hexdigest()[:16]
+        self.async_write_ha_state()
+
+    @property
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        if not self._media_control_enabled:
+            return MediaPlayerEntityFeature(0)
+        features = MediaPlayerEntityFeature(0)
+        actions = self._playback_actions
+        if actions & (ACTION_PLAY | ACTION_PLAY_PAUSE):
+            features |= MediaPlayerEntityFeature.PLAY
+        if actions & (ACTION_PAUSE | ACTION_PLAY_PAUSE):
+            features |= MediaPlayerEntityFeature.PAUSE
+        if actions & ACTION_STOP:
+            features |= MediaPlayerEntityFeature.STOP
+        if actions & ACTION_SKIP_TO_NEXT:
+            features |= MediaPlayerEntityFeature.NEXT_TRACK
+        if actions & ACTION_SKIP_TO_PREVIOUS:
+            features |= MediaPlayerEntityFeature.PREVIOUS_TRACK
+        if actions & ACTION_SEEK_TO:
+            features |= MediaPlayerEntityFeature.SEEK
+
+        if self._volume_control in ("relative", "absolute"):
+            features |= MediaPlayerEntityFeature.VOLUME_STEP | MediaPlayerEntityFeature.VOLUME_MUTE
+        if self._volume_control == "absolute":
+            features |= MediaPlayerEntityFeature.VOLUME_SET
+        return features
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        return {
+            "playing": MediaPlayerState.PLAYING,
+            "paused": MediaPlayerState.PAUSED,
+            "idle": MediaPlayerState.IDLE,
+            "off": MediaPlayerState.OFF,
+        }.get(self._playback_state or "")
+
+    @property
+    def media_title(self) -> str | None:
+        return self._media_title
+
+    @property
+    def media_duration(self) -> float | None:
+        return self._media_duration
+
+    @property
+    def media_position(self) -> float | None:
+        return self._playback_position
+
+    @property
+    def media_position_updated_at(self) -> datetime | None:
+        return self._playback_position_updated_at
+
+    @property
+    def app_id(self) -> str | None:
+        return self._application_id
+
+    @property
+    def app_name(self) -> str | None:
+        return {
+            "ru.yandex.music": "Yandex Music",
+            "com.google.android.youtube": "YouTube",
+            "com.google.android.youtube.tv": "YouTube",
+        }.get(self._application_id or "", self._application_id)
+
+    @property
+    def source(self) -> str | None:
+        return self.app_name
+
+    @property
+    def volume_level(self) -> float | None:
+        return self._volume_level
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        return self._volume_muted
+
+    @property
+    def media_image_url(self) -> str | None:
+        return f"mediasession2mqtt://{self._artwork_hash}" if self._artwork_hash else None
+
+    @property
+    def media_image_hash(self) -> str | None:
+        return self._artwork_hash
+
+    async def async_get_media_image(self) -> tuple[bytes | None, str | None]:
+        if self._artwork_bytes is None:
+            return None, None
+        return self._artwork_bytes, "image/jpeg"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "device_id": self._device_id,
+            "playback_actions": self._playback_actions,
+            "volume_control": self._volume_control,
+            "media_control_enabled": self._media_control_enabled,
+        }
+
+    async def _publish_command(self, command: str, payload: str = "1") -> None:
+        await mqtt.async_publish(
+            self.hass,
+            f"{self._root_topic}/command/{command}",
+            payload,
+            qos=0,
+            retain=False,
+        )
+
+    async def async_media_play(self) -> None:
+        await self._publish_command("play")
+
+    async def async_media_pause(self) -> None:
+        await self._publish_command("pause")
+
+    async def async_media_stop(self) -> None:
+        await self._publish_command("stop")
+
+    async def async_media_next_track(self) -> None:
+        await self._publish_command("next")
+
+    async def async_media_previous_track(self) -> None:
+        await self._publish_command("previous")
+
+    async def async_media_seek(self, position: float) -> None:
+        await self._publish_command("seek", str(max(0, round(position * 1000))))
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        await self._publish_command("volume", str(max(0.0, min(1.0, volume))))
+
+    async def async_volume_up(self) -> None:
+        await self._publish_command("volumeUp")
+
+    async def async_volume_down(self) -> None:
+        await self._publish_command("volumeDown")
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        await self._publish_command("mute" if mute else "unmute")

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "MediaSession2MQTT Player",
+  "render_readme": true
+}


### PR DESCRIPTION
Enables media control handling by native HASS [Media Player integration](https://www.home-assistant.io/integrations/media_player/) via adapter component (installable via HACS).


Media Control native card:
<img width="1035" height="510" alt="Screenshot 2026-08-27 at 23 32 29" src="https://github.com/user-attachments/assets/829fe276-afb5-4123-b586-4105782fc393" />
<br /><br /><br />

<img width="400" alt="Screenshot 2026-08-27 at 23 29 27" src="https://github.com/user-attachments/assets/f6218aee-78e4-4614-b275-c8b2027ebf47" />
<br />
<img width="400" alt="Screenshot 2026-08-27 at 23 29 43" src="https://github.com/user-attachments/assets/c2786668-3c4e-4122-8fe3-e9da55fc354a" />

Depends on my previous PR #24 